### PR TITLE
Compatibility Updates

### DIFF
--- a/src/Blazor.Auth0.ClientSide/Blazor.Auth0.ClientSide.csproj
+++ b/src/Blazor.Auth0.ClientSide/Blazor.Auth0.ClientSide.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
 
-    <Version>1.0.0-Preview2</Version>
+    <Version>1.0.0-Preview3</Version>
     <Authors>Henry Alberto Rodriguez Rodriguez</Authors>
     <Description>Auth0 library for Balzor</Description>
     <PackageProjectUrl>https://github.com/henalbrod/Blazor.Auth0</PackageProjectUrl>
@@ -24,8 +24,7 @@
 
   <ItemGroup>
     
-    <PackageReference Include="Blazor-Auth0-Shared" Version="1.0.0-Preview2" />
-    
+    <PackageReference Include="Blazor-Auth0-Shared" Version="1.0.0-Preview3" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0-rc1.19457.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.0.0-rc1.19457.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.0.0-rc1.19457.4" />

--- a/src/Blazor.Auth0.ClientSide/Models/AuthorizeOptions.cs
+++ b/src/Blazor.Auth0.ClientSide/Models/AuthorizeOptions.cs
@@ -4,6 +4,7 @@
 
 namespace Blazor.Auth0.Models
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using Blazor.Auth0.Models.Enumerations;
@@ -18,6 +19,11 @@ namespace Blazor.Auth0.Models
         /// </summary>
         [Required(ErrorMessage = "{0} option is required")]
         public string Domain { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Authorize Endpoint.
+        /// </summary>
+        public Uri AuthorizeEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the Auth0's tenant client id used in the authentication flow.

--- a/src/Blazor.Auth0.ServerSide/Blazor.Auth0.ServerSide.csproj
+++ b/src/Blazor.Auth0.ServerSide/Blazor.Auth0.ServerSide.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     
-    <Version>1.0.0-Preview2</Version>
+    <Version>1.0.0-Preview3</Version>
     <Authors>Henry Alberto Rodriguez Rodriguez</Authors>
     <Description>Auth0 library for Balzor</Description>
     <PackageProjectUrl>https://github.com/henalbrod/Blazor.Auth0</PackageProjectUrl>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor-Auth0-Shared" Version="1.0.0-Preview2" />
+    <PackageReference Include="Blazor-Auth0-Shared" Version="1.0.0-Preview3"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.0.0-rc1.19457.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="3.0.0-rc1.19457.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5-beta1.final">

--- a/src/Blazor.Auth0.Shared/Blazor.Auth0.Shared.csproj
+++ b/src/Blazor.Auth0.Shared/Blazor.Auth0.Shared.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 
-    <Version>1.0.0-Preview2</Version>
+    <Version>1.0.0-Preview3</Version>
     <Authors>Henry Alberto Rodriguez Rodriguez</Authors>
     <Description>Auth0 library for Balzor</Description>
     <PackageProjectUrl>https://github.com/henalbrod/Blazor.Auth0</PackageProjectUrl>

--- a/src/Blazor.Auth0.Shared/CommonAuthentication.cs
+++ b/src/Blazor.Auth0.Shared/CommonAuthentication.cs
@@ -65,19 +65,19 @@ namespace Blazor.Auth0
         /// Makes a call to the /userinfo endpoint and returns the user profile.
         /// </summary>
         /// <param name="httpClient">A <see cref="HttpClient"/> instance.</param>
-        /// <param name="auth0Domain">The Auth0's tenant domain.</param>
+        /// <param name="endpoint">The Auth0's tenant domain.</param>
         /// <param name="accessToken">The access_token received after the user authentication flow.</param>
         /// <returns>A <see cref="UserInfo"/>.</returns>
-        public static async Task<UserInfo> UserInfo(HttpClient httpClient, string auth0Domain, string accessToken)
+        public static async Task<UserInfo> UserInfo(HttpClient httpClient, string endpoint, string accessToken)
         {
             if (httpClient is null)
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }
 
-            if (string.IsNullOrEmpty(auth0Domain))
+            if (string.IsNullOrEmpty(endpoint))
             {
-                throw new ArgumentException(Resources.NullArgumentExceptionError, nameof(auth0Domain));
+                throw new ArgumentException(Resources.NullArgumentExceptionError, nameof(endpoint));
             }
 
             if (string.IsNullOrEmpty(accessToken))
@@ -87,7 +87,7 @@ namespace Blazor.Auth0
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-            HttpResponseMessage response = await httpClient.GetAsync($@"https://{auth0Domain}/userinfo").ConfigureAwait(false);
+            HttpResponseMessage response = await httpClient.GetAsync($@"{endpoint}").ConfigureAwait(false);
 
             string responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/Blazor.Auth0.Shared/Models/ClientOptions.cs
+++ b/src/Blazor.Auth0.Shared/Models/ClientOptions.cs
@@ -4,6 +4,7 @@
 
 namespace Blazor.Auth0.Models
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using Blazor.Auth0.Models.Enumerations;
@@ -32,6 +33,51 @@ namespace Blazor.Auth0.Models
         public string Connection { get; set; }
 
         /// <summary>
+        /// Gets or sets the Authorize Endpoint.
+        /// </summary>
+        public Uri AuthorizeEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Token Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration.
+        /// </summary>
+        public Uri TokenEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UserInfo Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration.
+        /// Currently not used.
+        /// </summary>
+        public Uri UserInfoEnpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Device Authorization Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration.
+        /// </summary>
+        public Uri DeviceAuthorizationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Introspection Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration.
+        /// Currently not used.
+        /// </summary>
+        public Uri IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets Revocation Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration./// 
+        /// </summary>
+        public Uri RevocationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets End Session Endpoint.
+        /// Do not configure if your Auth server has a .well-known/openid-configuration.
+        /// Currently not used.
+        /// </summary>
+        public Uri EndSessionEndpoint { get; set; }
+
+
+        /// <summary>
         /// Gets or sets url that the Auth0 will redirect to after user authentication. Defaults to an empty string (none). This value overrides RedirectAlwaysToHome.
         /// </summary>
         public string RedirectUri { get; set; }
@@ -51,6 +97,11 @@ namespace Blazor.Auth0.Models
         /// Gets or sets row the Auth response is encoded and redirected back to the client. Supported values are `query`, `fragment` and `form_post`.
         /// </summary>
         public ResponseModes ResponseMode { get; set; } = ResponseModes.Query;
+
+        /// <summary>
+        /// Gets or sets row the Auth request is encoded  Supported values are `json`, and `form_post`.
+        /// </summary>
+        public RequestModes RequestMode { get; set; } = RequestModes.Json;
 
         /// <summary>
         /// Gets or sets the default scope(s) used by the application. Using scopes can allow you to return specific claims for specific fields in your request. You should read our [documentation on scopes][https://auth0.com/docs/scopes] for further details, default = openid profile email.

--- a/src/Blazor.Auth0.Shared/Models/Enumerations.cs
+++ b/src/Blazor.Auth0.Shared/Models/Enumerations.cs
@@ -4,6 +4,17 @@
 
 namespace Blazor.Auth0.Models.Enumerations
 {
+    public enum Endpoint
+    {
+        Authorize = 0,
+        Token = 1,
+        UserInfo = 2,
+        Device_Authorization = 3,
+        Introspection = 4,
+        Revocation = 5,
+        End_Session = 6
+    }
+
     public enum SessionStates
     {
         Undefined = 0,
@@ -49,6 +60,12 @@ namespace Blazor.Auth0.Models.Enumerations
         Query,
         Fragment,
         Form_Post,
+    }
+
+    public enum RequestModes
+    {
+        Json = 0,
+        Form_Post
     }
 
     public enum CodeChallengeMethods

--- a/src/Blazor.Auth0.Shared/Models/OpenidConfiguration.cs
+++ b/src/Blazor.Auth0.Shared/Models/OpenidConfiguration.cs
@@ -1,0 +1,149 @@
+﻿namespace Blazor.Auth0.Shared.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Class for representing the openid configuration.
+    /// </summary>
+    public class OpenidConfiguration
+    {
+        /// <summary>
+        /// Gets or sets issuer.
+        /// </summary>
+        [JsonPropertyName("issuer")]
+        public Uri Issuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets jwks_uri.
+        /// </summary>
+        [JsonPropertyName("jwks_uri")]
+        public Uri JwksUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets authorization endpoint.
+        /// </summary>
+        [JsonPropertyName("authorization_endpoint")]
+        public Uri AuthorizationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets token endpoint.
+        /// </summary>
+        [JsonPropertyName("token_endpoint")]
+        public Uri TokenEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets userinfo endpoint.
+        /// </summary>
+        [JsonPropertyName("userinfo_endpoint")]
+        public Uri UserinfoEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets end session endpoint.
+        /// </summary>
+        [JsonPropertyName("end_session_endpoint")]
+        public Uri EndSessionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets issuer check session iframe.
+        /// </summary>
+        [JsonPropertyName("check_session_iframe")]
+        public Uri CheckSessionIframe { get; set; }
+
+        /// <summary>
+        /// Gets or sets revocation endpoint.
+        /// </summary>
+        [JsonPropertyName("revocation_endpoint")]
+        public Uri RevocationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets introspection endpoint.
+        /// </summary>
+        [JsonPropertyName("introspection_endpoint")]
+        public Uri IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets device authorization endpoint.
+        /// </summary>
+        [JsonPropertyName("device_authorization_endpoint")]
+        public Uri DeviceAuthorizationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether frontchannel logout supported.
+        /// </summary>
+        [JsonPropertyName("frontchannel_logout_supported")]
+        public bool FrontchannelLogoutSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether frontchannel logout session supported.
+        /// </summary>
+        [JsonPropertyName("frontchannel_logout_session_supported")]
+        public bool FrontchannelLogoutSessionSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether backchannel logout supported.
+        /// </summary>
+        [JsonPropertyName("backchannel_logout_supported")]
+        public bool BackchannelLogoutSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether backchannel logout session supported.
+        /// </summary>
+        [JsonPropertyName("backchannel_logout_session_supported")]
+        public bool BackchannelLogoutSessionSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets scopes supported.
+        /// </summary>
+        [JsonPropertyName("scopes_supported")]
+        public string[] ScopesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets claims supported.
+        /// </summary>
+        [JsonPropertyName("claims_supported")]
+        public object[] ClaimsSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets grant types supported.
+        /// </summary>
+        [JsonPropertyName("grant_types_supported")]
+        public string[] GrantTypesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets response types supported.
+        /// </summary>
+        [JsonPropertyName("response_types_supported")]
+        public string[] ResponseTypesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets response modes supported.
+        /// </summary>
+        [JsonPropertyName("response_modes_supported")]
+        public string[] ResponseModesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets token endpoint auth methods supported.
+        /// </summary>
+        [JsonPropertyName("token_endpoint_auth_methods_supported")]
+        public string[] TokenEndpointAuthMethodsSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets subject types supported.
+        /// </summary>
+        [JsonPropertyName("subject_types_supported")]
+        public string[] SubjectTypesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets token signing values supported.
+        /// </summary>
+        [JsonPropertyName("id_token_signing_alg_values_supported")]
+        public string[] IdTokenSigningAlgValuesSupported { get; set; }
+
+        /// <summary>
+        /// Gets or sets code challenge methods supported.
+        /// </summary>
+        [JsonPropertyName("code_challenge_methods_supported")]
+        public string[] CodeChallengeMethodsSupported { get; set; }
+    }
+}


### PR DESCRIPTION
- Adds Support for reading the .well-known/openid-configuration and using correct endpoints
- Adds Support for setting request type. Some Auth Servers do not allow JSON in the body. IG IdentityServer at least by default.
