### PR TITLE
Pass the redirectUri through to the logouturl builder [ClientSide]

### DIFF
--- a/src/Blazor.Auth0.ClientSide/AuthenticationService.cs
+++ b/src/Blazor.Auth0.ClientSide/AuthenticationService.cs
@@ -109,7 +109,7 @@ namespace Blazor.Auth0
         /// <inheritdoc/>
         public async Task LogOut(string redirectUri = null)
         {
-            string logoutUrl = CommonAuthentication.BuildLogoutUrl(this.clientOptions.Domain, this.clientOptions.ClientId);
+            string logoutUrl = CommonAuthentication.BuildLogoutUrl(this.clientOptions.Domain, this.clientOptions.ClientId, redirectUri);
 
             await this.jsRuntime.InvokeAsync<object>($"{Resources.InteropElementName}.logOut", logoutUrl).ConfigureAwait(false);
 


### PR DESCRIPTION
Updated to pass the redirect uri that is specified to be passed through the logout builder, today it's not honored by the builder so auth0 just performs a default redirect.